### PR TITLE
devcontainer: Install @lightprotocol/cli

### DIFF
--- a/devcontainer-core/Dockerfile
+++ b/devcontainer-core/Dockerfile
@@ -11,19 +11,19 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 RUN update-alternatives --set editor /usr/bin/nvim
 
 USER node
+WORKDIR /home/node
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/home/node/.cargo/bin:${PATH}"
 RUN rustup toolchain install nightly
 
-RUN yarn global add @lightprotocol/light
-
 RUN curl -s \
     https://raw.githubusercontent.com/Lightprotocol/install/main/light-protocol-install.sh | \
     bash -s -- --no-prompt
-RUN echo "PATH=$PATH:/home/node/.cargo/bin:/home/node/.local/light-protocol/bin:/home/node/.config/yarn/global/node_modules/.bin" >> \
-    /home/node/.profile
-RUN echo "PATH=$PATH:/home/node/.cargo/bin:/home/node/.local/light-protocol/bin:/home/node/.config/yarn/global/node_modules/.bin" >> \
+
+RUN echo "PATH=\"/home/node/.cargo/bin:\$PATH\"" >> /home/node/.bashrc
+RUN echo "PATH=\"/home/node/.local/light-protocol/bin:\$PATH\"" >> /home/node/.bashrc
+RUN echo "PATH=\"\$(yarn global bin):\$PATH\"" >> \
     /home/node/.bashrc
 
 ARG NOOP_PROGRAM_VERSION=0.1.3

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -4,6 +4,8 @@ FROM ${BASE_IMAGE}
 
 USER node
 
+RUN yarn global add @lightprotocol/cli
+
 RUN curl -s \
     https://raw.githubusercontent.com/Lightprotocol/install/main/light-protocol-install.sh | \
     bash -s -- --no-prompt --skip-toolchain


### PR DESCRIPTION
* The name of CLI NPM package changed from @lightprotocol/light to @lightprotocol/cli.
* We should install it in devcontainer, not devcontainer-core - it's needed for development of PSPs, but when developing Light Protocol itself, we should build CLI always from source.