### PR TITLE
solana-test-validator: Expose ports explicitly

### DIFF
--- a/solana-test-validator/Dockerfile
+++ b/solana-test-validator/Dockerfile
@@ -2,6 +2,39 @@ ARG BASE_IMAGE=ghcr.io/lightprotocol/devcontainer:main
 
 FROM ${BASE_IMAGE}
 
+# RPC JSON
+EXPOSE 8899/tcp
+# RPC pubsub
+EXPOSE 8900/tcp
+# entrypoint
+EXPOSE 8001/tcp
+# (future) bank service
+EXPOSE 8901/tcp
+# bank service
+EXPOSE 8902/tcp
+# faucet
+EXPOSE 9900/tcp
+# tvu
+EXPOSE 8000/udp
+# gossip
+EXPOSE 8001/udp
+# tvu_forwards
+EXPOSE 8002/udp
+# tpu
+EXPOSE 8003/udp
+# tpu_forwards
+EXPOSE 8004/udp
+# retransmit
+EXPOSE 8005/udp
+# repair
+EXPOSE 8006/udp
+# serve_repair
+EXPOSE 8007/udp
+# broadcast
+EXPOSE 8008/udp
+# tpu_vote
+EXPOSE 8009/udp
+
 COPY entrypoint.sh /home/node/.local/light-protocol/bin/entrypoint.sh
 
 ENTRYPOINT ["/home/node/.local/light-protocol/bin/entrypoint.sh"]


### PR DESCRIPTION
Docker on macOS doesn't support the `--net=host` option, so we have to expose and map all validator ports explicitly.