### PR TITLE
CI: Add a cron schedule to rebuild images daily

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This way we make sure that the `main` tag always has the newest packages and Rust toolchain.